### PR TITLE
Update: Hashstack's status for mainnet

### DIFF
--- a/data/ecosystem.ts
+++ b/data/ecosystem.ts
@@ -537,8 +537,8 @@ export const allProjects: Array<Project> = [
       discord: "http://hashstack.community",
       telegram: "",
     },
-    isLive: false,
-    isTestnetLive: false,
+    isLive: true,
+    isTestnetLive: true,
   },
   {
     id: "d95046cb-7ce0-4f3f-9d1c-7214acc30bc7",


### PR DESCRIPTION
Hashstack is live on Mainnet [permissioned access] for Cairo v0.10.