### PR TITLE
Correction: Capitalization of Language Name

### DIFF
--- a/src/assets/locales/README.md
+++ b/src/assets/locales/README.md
@@ -6,4 +6,4 @@ Everything about translations is available under `src/assets/locales`.
 
 You can simply copy `en.ts` to the language you want to translate in. E.g: `fr.ts`.
 
-Translate all items inside the translations. If you can't find a good translation concerning a tag keep the english one please.
+Translate all items inside the translations. If you can't find a good translation concerning a tag keep the English one please.


### PR DESCRIPTION
Hello,

## Explanation
Language names are typically capitalized, so I emphasized "English" with uppercase letters.

Thank you.
