### PR TITLE
correction to broken nav links

### DIFF
--- a/data/academy.ts
+++ b/data/academy.ts
@@ -391,7 +391,7 @@ export const learning: Resource[] = [
       "A specialized educational platform dedicated to empower students with zk-STARK technology, the Cairo programming language, and the StarkNet contract architecture",
     tags: ["learn"],
     network: {
-      website: "https://starklearn.com/Blogs/",
+      website: "https://starklearn.com/",
     },
   },
 ];


### PR DESCRIPTION
I clicked on starknet learn under starknet academy and it led me to a wierd looking page.
Here is the broken link: 
https://starklearn.com/Blogs/

So i changed it to this: https://starklearn.com/ and it works just fine. 
I tried attaching a screenshot the page below: 

[
![Screenshot from 2024-05-15 22-37-48](https://github.com/419Labs/starknet-ecosystem.com/assets/107637548/16823037-74fc-49e0-b77e-59e0533cfa9d)
