### PR TITLE
fix: update retired Starknet.js links

### DIFF
--- a/data/ecosystem.ts
+++ b/data/ecosystem.ts
@@ -4274,7 +4274,7 @@ export const allProjects: Array<Project> = [
     tags: ["tools"],
     image: "StarknetJS.png",
     network: {
-      website: "https://starknetjs.com/",
+      website: "https://starknet-js.com/",
       github: "https://github.com/starknet-io/starknet.js",
       twitter: "",
       medium: "",

--- a/src/pages/academy/index.tsx
+++ b/src/pages/academy/index.tsx
@@ -295,7 +295,7 @@ const AcademyPage: FC = () => {
   ];
 
   const sdks = [
-    { name: "starknet.js", href: "https://www.starknetjs.com/" },
+    { name: "starknet.js", href: "https://starknet-js.com/" },
     { name: "starknet.py", href: "https://starknetpy.readthedocs.io/" },
     { name: "starknet-rs", href: "https://github.com/xJonathanLEI/starknet-rs" },
     { name: "starknet.go", href: "https://github.com/NethermindEth/starknet.go" },


### PR DESCRIPTION
## Summary
- update the Academy SDK link to use `starknet-js.com`
- update the Starknet.js ecosystem listing to the current website

## Validation
- `git diff --check`
- verified `https://starknet-js.com/` returns HTTP 200

## Not run
- `yarn lint`: the local Yarn runtime aborts before it can execute.